### PR TITLE
added 360w guide button to mapping

### DIFF
--- a/xinput_host.c
+++ b/xinput_host.c
@@ -455,6 +455,7 @@ bool xinputh_xfer_cb(uint8_t dev_addr, uint8_t ep_addr, xfer_result_t result, ui
                 if (wButtons & (1 << 7)) pad->wButtons |= XINPUT_GAMEPAD_RIGHT_THUMB;
                 if (wButtons & (1 << 8)) pad->wButtons |= XINPUT_GAMEPAD_LEFT_SHOULDER;
                 if (wButtons & (1 << 9)) pad->wButtons |= XINPUT_GAMEPAD_RIGHT_SHOULDER;
+                if (wButtons & (1 << 10)) pad->wButtons |= XINPUT_GAMEPAD_GUIDE;
                 if (wButtons & (1 << 12)) pad->wButtons |= XINPUT_GAMEPAD_A;
                 if (wButtons & (1 << 13)) pad->wButtons |= XINPUT_GAMEPAD_B;
                 if (wButtons & (1 << 14)) pad->wButtons |= XINPUT_GAMEPAD_X;


### PR DESCRIPTION
Minor oversight on the 360 wireless mapping was the lack of the guide button being brought forward to the user.

As an aside I notice you check the connect/disconnect packet for the status of the device, but you *only* call `tuh_xinput_report_received_cb` when there is `new_pad_data`. That leaves the caller oblivious to know when a pad has been disconnected.

Should we be calling `tuh_xinput_report_received_cb` on a disconnect and expect it to check `connected` to preform operations when the pad was disconnected/reconnected?

Or how else can we let the host code know that a 360 wireless gamepad has been disconnected?