### PR TITLE
Fix return type and value for xinputh_open to conform to new API

### DIFF
--- a/xinput_host.c
+++ b/xinput_host.c
@@ -256,7 +256,7 @@ bool xinputh_init(void)
     return true;
 }
 
-bool xinputh_open(uint8_t rhport, uint8_t dev_addr, tusb_desc_interface_t const *desc_itf, uint16_t max_len)
+uint16_t xinputh_open(uint8_t rhport, uint8_t dev_addr, tusb_desc_interface_t const *desc_itf, uint16_t max_len)
 {
     TU_VERIFY(dev_addr <= CFG_TUH_DEVICE_MAX);
 
@@ -322,7 +322,7 @@ bool xinputh_open(uint8_t rhport, uint8_t dev_addr, tusb_desc_interface_t const 
     }
 
     xinput_dev->inst_count++;
-    return true;
+    return pos;
 }
 
 bool xinputh_set_config(uint8_t dev_addr, uint8_t itf_num)


### PR DESCRIPTION
This resolves Issue #15 .

* The function signature has been changed from returning `bool` to `uint16_t` as the `usbh_class_driver_t` defines.
* The function now returns `pos` variable which tracks the amount of consumed bytes in the description buffer.

Compiles in my project.